### PR TITLE
Installed remark-cli for MarkDownBear

### DIFF
--- a/thoth-coala-ubi8/Dockerfile
+++ b/thoth-coala-ubi8/Dockerfile
@@ -16,6 +16,7 @@ COPY ./ /tmp/src-thoth-coala
 COPY ./root/ /
 
 RUN yum install -y python2 && \
+    npm install -g remark-cli && \
     pip3 install --requirement /tmp/src-thoth-coala/requirements.txt
 
 USER ${USERID}

--- a/thoth-coala/Dockerfile
+++ b/thoth-coala/Dockerfile
@@ -16,6 +16,7 @@ RUN DEINSTALL_PKGS="gd-devel openssl-devel zlib-devel libcurl-devel libxml2-deve
     make autoconf automake bzip2 gcc-c++ patch gdb procps-ng unzip wget" && \
     chmod 777 -R /tmp/src-thoth-coala && \
     pushd /tmp/src-thoth-coala && \
+    npm install -g remark-cli && \
     pip3 install --requirement requirements.txt && \
     dnf remove -y $DEINSTALL_PKGS
 


### PR DESCRIPTION
Installed remark-cli for MarkDownBear
Fixes: #17 
MarkdownBear is giving out error for missing remark.
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>