### PR TITLE
add a script to run pytest and micropipenv

### DIFF
--- a/thoth-pytest-ubi8-py38/Dockerfile
+++ b/thoth-pytest-ubi8-py38/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.20.1
+FROM quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.24.2
 
 ENV SUMMARY="Thoth's toolchain for pytest." \
     DESCRIPTION="Thoth's toolchain for pytest."
@@ -12,9 +12,11 @@ LABEL summary="$SUMMARY" \
 
 USER 0
 COPY ./ /tmp/src-thoth-pytest
-RUN  \
-  pip install --upgrade pip &&\
-  /usr/bin/python3 -m pip install --upgrade pip &&\
-  /usr/bin/python3 -m pip install --requirement /tmp/src-thoth-pytest/requirements.txt
+RUN pip install --upgrade pip && \
+    /usr/bin/python3 -m pip install --upgrade pip && \
+    /usr/bin/python3 -m pip install --requirement /tmp/src-thoth-pytest/requirements.txt
+
+COPY root/ /
+RUN chmod 755 /bin/run-pytest
 
 USER ${USERID}

--- a/thoth-pytest-ubi8-py38/root/bin/run-pytest
+++ b/thoth-pytest-ubi8-py38/root/bin/run-pytest
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -o errexit
+trap 'echo "Aborting due to errexit on line $LINENO. Exit code: $?" >&2' ERR
+set -o errtrace
+set -o pipefail
+
+if [[ -f setup.py ]]; then
+    micropipenv install --dev
+    python3 setup.py test 2>&1
+fi
+
+#end.


### PR DESCRIPTION
This adds a tiny script to run micropipenv and pytest, it could be reused for prow jobs or tekton tasks.

Signed-off-by: Christoph Görn <goern@redhat.com>