### PR TITLE
silent pipenv installation unless debugging

### DIFF
--- a/thoth-pytest-ubi8-py38/root/bin/run-mypy
+++ b/thoth-pytest-ubi8-py38/root/bin/run-mypy
@@ -5,7 +5,12 @@ trap 'echo "Aborting due to errexit on line $LINENO. Exit code: $?" >&2' ERR
 set -o errtrace
 set -o pipefail
 
-micropipenv install --dev
+if [ "$DEBUG" == "1" ];
+    micropipenv install --dev
+else
+    micropipenv install --dev > /dev/null
+fi
+
 mypy "$@"
 
 #end.


### PR DESCRIPTION

https://prow.operate-first.cloud/view/s3/ci-prow-artifacts--36f9ca3b-f5af-4432-bef8-af42508b403e/prow-logs/pr-logs/pull/thoth-station_advise-reporter/198/thoth-mypy-py38/1386801986757726208

In outputs like this we really only care about the lines pertaining to `mypy` output`
