### PR TITLE
feat: Add OPA and Conftest binaries

### DIFF
--- a/thoth-precommit-ubi-py38/Dockerfile
+++ b/thoth-precommit-ubi-py38/Dockerfile
@@ -18,4 +18,12 @@ RUN  \
   /usr/bin/python3 -m pip install --upgrade pip &&\
   /usr/bin/python3 -m pip install --requirement /tmp/src-thoth-precommit/requirements.txt
 
+ARG OPA_VERSION="0.31.0"
+ARG CONFTEST_VERSION="0.21.0"
+RUN \
+    curl -L https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz | tar -xzf - -C /usr/local/bin && \
+    curl -o /usr/local/bin/opa -L https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}/opa_linux_amd64_static && \
+    chmod +x /usr/local/bin/opa /usr/local/bin/conftest
+
+
 USER ${USERID}


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/operate-first/workshop-apps/pull/33#issuecomment-897554361

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements


Pre-commit using [anderseknert/pre-commit-opa](https://github.com/anderseknert/pre-commit-opa) fails to run via Thoth image because `conftest` and `opa` binaries are missing. This PR adds them


/cc @harshad16 

Can you please release new version of this image once the PR gets merged?
