### PR TITLE
Direct invocation of pytest instead of relying on setup.py

### DIFF
--- a/thoth-pytest-py36/root/bin/run-pytest
+++ b/thoth-pytest-py36/root/bin/run-pytest
@@ -11,7 +11,7 @@ if [[ -f setup.py ]]; then
     else
         micropipenv install --dev > /dev/null
     fi
-    python3 setup.py test 2>&1
+    pytest
 fi
 
 #end.

--- a/thoth-pytest-py38/root/bin/run-pytest
+++ b/thoth-pytest-py38/root/bin/run-pytest
@@ -11,7 +11,7 @@ if [[ -f setup.py ]]; then
     else
         micropipenv install --dev > /dev/null
     fi
-    python3 setup.py test 2>&1
+    pytest
 fi
 
 #end.


### PR DESCRIPTION
## Related Issues and Dependencies

fix #74
…

## This introduces a breaking change

- [x] Yes

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
Repos relying on using setup.py for running tests (aka, direct `pytest` does not work) will not work

## Description

<!--- Describe your changes in detail -->
We use only pytest on thoth-* repos right now (I think ?), so we don't need a "frontend".
In the future if we do, we'll switch to something like tox.
